### PR TITLE
Implement additional recombination schemes

### DIFF
--- a/cluster.h
+++ b/cluster.h
@@ -1,6 +1,12 @@
 #ifndef cluster_h
 #define cluster_h
 
-void cluster(PseudoJet *particles, int size, double r);
+enum class Scheme {
+  Kt = 1,
+  CambridgeAachen = 0,
+  AntiKt = -1
+};
+
+void cluster(PseudoJet *particles, int size, Scheme scheme, double r);
 
 #endif  // cluster_h

--- a/main.cc
+++ b/main.cc
@@ -95,8 +95,9 @@ void print_jets(std::vector<PseudoJet> const& jets, bool cartesian = false) {
 }
 
 int main(int argc, const char* argv[]) {
-  double ptmin = 0.0;  // GeV
-  double r = 1.0;      // clustering radius
+  double ptmin = 0.0;           // GeV
+  double r = 1.0;               // clustering radius
+  Scheme scheme = Scheme::Kt;   // recombination scheme
   bool sort = true;
   bool cartesian = false;
   int repetitions = 1;
@@ -170,6 +171,21 @@ int main(int argc, const char* argv[]) {
       cartesian = false;
     } else
 
+    // --kt, -kt
+    if (std::strcmp(argv[i], "--kt") == 0 or std::strcmp(argv[i], "-kt") == 0) {
+      scheme = Scheme::Kt;
+    } else
+
+    // --anti-kt, -antikt
+    if (std::strcmp(argv[i], "--anti-kt") == 0 or std::strcmp(argv[i], "-antikt") == 0) {
+      scheme = Scheme::AntiKt;
+    } else
+
+    // --cambridge-aachen, -cam
+    if (std::strcmp(argv[i], "--cambridge-aachen") == 0 or std::strcmp(argv[i], "-cam") == 0){
+      scheme = Scheme::CambridgeAachen;
+    } else
+
     // unknown option
     {
       // error
@@ -200,7 +216,7 @@ int main(int argc, const char* argv[]) {
       cudaCheck(cudaMemcpy(particles_d, particles.data(), sizeof(PseudoJet) * particles.size(), cudaMemcpyDefault));
 
       // run the clustering algorithm and measure its running time
-      cluster(particles_d, particles.size(), r);
+      cluster(particles_d, particles.size(), scheme, r);
 
       // copy the clustered jets back to the CPU
       jets.resize(particles.size());


### PR DESCRIPTION
Implement the
  - Kt
  - AntKt
  - Cambridge-Aachen

recombination schemes for the `tri_matrix` and `grid` algorithms.

At the command line options to choose which scheme to use, and the format of the output (cartesian vs cylindrical).