### PR TITLE
Miscellaneous changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ CXX_FLAGS=-std=c++17 -O2 -g -I$(CUDA_INCLUDE_PATH) -I$(CUB_INCLUDE_PATH)
 LD_FLAGS=-L$(CUDA_LIBRARY_PATH) -lcudart -lcuda
 
 NVCC=$(CUDA_BASE)/bin/nvcc -ccbin $(CXX)
-NVCC_FLAGS=-std=c++14 -O2 -g --generate-line-info --source-in-ptx --generate-code arch=compute_50,code=sm_50 -I$(CUB_INCLUDE_PATH)
+NVCC_FLAGS=-std=c++14 -O2 --expt-relaxed-constexpr --expt-extended-lambda -g --generate-line-info --source-in-ptx --generate-code arch=compute_50,code=sm_50 -I$(CUB_INCLUDE_PATH)
 
 
 all: grid n_array tri_matrix tri_matrix_empty

--- a/main.cc
+++ b/main.cc
@@ -24,6 +24,11 @@ void initialise() {
   int value;
   cudaDeviceGetAttribute(&value, cudaDevAttrMaxSharedMemoryPerBlock, 0);
   std::cout << "  - maximum shared memory per block: " << value / 1024 << " kB" << std::endl;
+
+  cudaCheck(cudaDeviceSetLimit(cudaLimitPrintfFifoSize, 10*1024*1024));
+  size_t size;
+  cudaCheck(cudaDeviceGetLimit(&size, cudaLimitPrintfFifoSize));
+  std::cout << "  - kernel printf buffer size:       " << size / 1024 << " kB" << std::endl;
 }
 
 bool read_next_event(std::istream& input, std::vector<PseudoJet>& particles) {


### PR DESCRIPTION
Increase the size of the ring buffer used by device-side `printf` to 10 MB.
Enable support for `constexpr` functions and extended lambdas in device code.