### PR TITLE
Optimize the grid implementation,  part 4

### DIFF
--- a/cluster.h
+++ b/cluster.h
@@ -1,11 +1,7 @@
 #ifndef cluster_h
 #define cluster_h
 
-enum class Algorithm {
-  Kt = 1,
-  CambridgeAachen = 0,
-  AntiKt = -1
-};
+enum class Algorithm { Kt = 1, CambridgeAachen = 0, AntiKt = -1 };
 
 void cluster(PseudoJet *particles, int size, Algorithm algo, double r);
 

--- a/cluster.h
+++ b/cluster.h
@@ -1,12 +1,12 @@
 #ifndef cluster_h
 #define cluster_h
 
-enum class Scheme {
+enum class Algorithm {
   Kt = 1,
   CambridgeAachen = 0,
   AntiKt = -1
 };
 
-void cluster(PseudoJet *particles, int size, Scheme scheme, double r);
+void cluster(PseudoJet *particles, int size, Algorithm algo, double r);
 
 #endif  // cluster_h

--- a/grid.cu
+++ b/grid.cu
@@ -56,7 +56,7 @@ struct Grid {
         max_rap(max_rap),
         min_phi(min_phi),
         max_phi(min_phi),
-        r((2 * M_PI) / (int)((2 * M_PI) / r)),            // round up the grid size to have an integer number of cells in phi
+        r((2 * M_PI) / (int)((2 * M_PI) / r)),  // round up the grid size to have an integer number of cells in phi
         max_i((GridIndexType)(((max_rap - min_rap) / r))),
         max_j((GridIndexType)(((max_phi - min_phi) / r))),
         n(n),
@@ -369,7 +369,7 @@ __global__ void reduce_recombine(
         min_dists[tid] = local_min;
       }
 
-      sdata[tid] = local_min; 
+      sdata[tid] = local_min;
     }
     __syncthreads();
 

--- a/grid.cu
+++ b/grid.cu
@@ -316,23 +316,6 @@ __global__ void reduce_recombine(
           local_min = minimum_in_cell(grid, points, local_min, tid, p.box_i - 1, j, one_over_r2);
         }
 
-#if 0
-        if (p.box_j == grid.max_j - 2) {
-          // Up Up
-          local_min = minimum_in_cell(grid, points, local_min, tid, p.box_i, 0, one_over_r2);
-
-          // Up Up Right
-          if (right) {
-            local_min = minimum_in_cell(grid, points, local_min, tid, p.box_i + 1, 0, one_over_r2);
-          }
-
-          // Up Up Left
-          if (left) {
-            local_min = minimum_in_cell(grid, points, local_min, tid, p.box_i - 1, 0, one_over_r2);
-          }
-        }
-#endif
-
         // check if (p.box_j - 1) would underflow below 0
         j = p.box_j - 1 >= 0 ? p.box_j - 1 : grid.max_j - 1;
 
@@ -348,23 +331,6 @@ __global__ void reduce_recombine(
         if (left) {
           local_min = minimum_in_cell(grid, points, local_min, tid, p.box_i - 1, j, one_over_r2);
         }
-
-#if 0
-        if (p.box_j == 0) {
-          // Down Down
-          local_min = minimum_in_cell(grid, points, local_min, tid, p.box_i, j - 1, one_over_r2);
-
-          // Down Down Right
-          if (right) {
-            local_min = minimum_in_cell(grid, points, local_min, tid, p.box_i + 1, j - 1, one_over_r2);
-          }
-
-          // Down Down Left
-          if (left) {
-            local_min = minimum_in_cell(grid, points, local_min, tid, p.box_i - 1, j - 1, one_over_r2);
-          }
-        }
-#endif
 
         min_dists[tid] = local_min;
       }

--- a/grid.cu
+++ b/grid.cu
@@ -6,8 +6,6 @@
 #include "cluster.h"
 #include "cudaCheck.h"
 
-using namespace std;
-
 #pragma region consts
 const double MaxRap = 1e5;
 #pragma endregion

--- a/main.cc
+++ b/main.cc
@@ -116,9 +116,9 @@ void print_jets(std::vector<PseudoJet> const& jets, bool cartesian = false) {
 }
 
 int main(int argc, const char* argv[]) {
-  double ptmin = 0.0;          // GeV
-  double r = 1.0;              // clustering radius
-  Scheme scheme = Scheme::Kt;  // recombination scheme
+  double ptmin = 0.0;              // GeV
+  double r = 1.0;                  // clustering radius
+  Algorithm algo = Algorithm::Kt;  // clustering algorithm
   bool sort = true;
   bool cartesian = false;
   int repetitions = 1;
@@ -201,17 +201,17 @@ int main(int argc, const char* argv[]) {
 
     // --kt, -kt
     if (std::strcmp(argv[i], "--kt") == 0 or std::strcmp(argv[i], "-kt") == 0) {
-      scheme = Scheme::Kt;
+      algo = Algorithm::Kt;
     } else
 
     // --anti-kt, -antikt
     if (std::strcmp(argv[i], "--anti-kt") == 0 or std::strcmp(argv[i], "-antikt") == 0) {
-      scheme = Scheme::AntiKt;
+      algo = Algorithm::AntiKt;
     } else
 
     // --cambridge-aachen, -cam
     if (std::strcmp(argv[i], "--cambridge-aachen") == 0 or std::strcmp(argv[i], "-cam") == 0) {
-      scheme = Scheme::CambridgeAachen;
+      algo = Algorithm::CambridgeAachen;
     } else
 
     // --file, -f
@@ -291,7 +291,7 @@ int main(int argc, const char* argv[]) {
       cudaCheck(cudaMemcpy(particles_d, particles.data(), sizeof(PseudoJet) * particles.size(), cudaMemcpyDefault));
 
       // run the clustering algorithm and measure its running time
-      cluster(particles_d, particles.size(), scheme, r);
+      cluster(particles_d, particles.size(), algo, r);
 
       // copy the clustered jets back to the CPU
       jets.resize(particles.size());

--- a/tri_matrix_empty.cu
+++ b/tri_matrix_empty.cu
@@ -36,15 +36,15 @@ struct PseudoJetExt {
   double rap;
   bool isJet;
 
-  __host__ __device__ double get_diB(Scheme scheme) const {
-    switch (scheme) {
-      case Scheme::Kt:
+  __host__ __device__ double get_diB(Algorithm algo) const {
+    switch (algo) {
+      case Algorithm::Kt:
         return diB;
 
-      case Scheme::CambridgeAachen:
+      case Algorithm::CambridgeAachen:
         return 1.;
 
-      case Scheme::AntiKt:
+      case Algorithm::AntiKt:
         return diB > 1e-300 ? 1.0 / diB : 1e300;
     }
     // never reached
@@ -108,8 +108,8 @@ __device__ double plain_distance(PseudoJetExt &jet1, PseudoJetExt &jet2) {
   return (dphi * dphi + drap * drap);
 }
 
-__device__ double yij_distance(PseudoJetExt &jet1, PseudoJetExt &jet2, Scheme scheme, double one_over_r2) {
-  return min(jet1.get_diB(scheme), jet2.get_diB(scheme)) * plain_distance(jet1, jet2) * one_over_r2;
+__device__ double yij_distance(PseudoJetExt &jet1, PseudoJetExt &jet2, Algorithm algo, double one_over_r2) {
+  return min(jet1.get_diB(algo), jet2.get_diB(algo)) * plain_distance(jet1, jet2) * one_over_r2;
 }
 
 __device__ void tid_to_ij(int &i, int &j, int tid) {
@@ -141,7 +141,7 @@ __global__ void reduction_min(PseudoJetExt *jets,
                               Dist *distances_out,
                               int const distances_array_size,
                               int const num_particles,
-                              Scheme scheme,
+                              Algorithm algo,
                               double one_over_r2) {
 #if 0
   // Specialize BlockReduce type for our thread block
@@ -157,9 +157,9 @@ __global__ void reduction_min(PseudoJetExt *jets,
   if (tid >= distances_array_size || dst.j >= num_particles || dst.i >= num_particles) {
     dst.d = MAX_DOUBLE;
   } else if (dst.i == dst.j) {
-    dst.d = jets[dst.i].get_diB(scheme);
+    dst.d = jets[dst.i].get_diB(algo);
   } else {
-    dst.d = yij_distance(jets[dst.i], jets[dst.j], scheme, one_over_r2);
+    dst.d = yij_distance(jets[dst.i], jets[dst.j], algo, one_over_r2);
   }
 
   Dist min = BlockReduceT(sdata).Reduce(dst, dist_compare());
@@ -254,7 +254,7 @@ __global__ void output(const PseudoJetExt *jets, PseudoJet *particles, int size)
 #endif
 }
 
-void cluster(PseudoJet *particles, int size, Scheme scheme, double r) {
+void cluster(PseudoJet *particles, int size, Algorithm algo, double r) {
 #pragma regoin CudaMalloc
   PseudoJetExt *d_jets;
   cudaCheck(cudaMalloc(&d_jets, size * sizeof(PseudoJetExt)));
@@ -277,7 +277,7 @@ void cluster(PseudoJet *particles, int size, Scheme scheme, double r) {
     num_blocks = (num_threads / 1024) + 1;
 
     // Find the minimum in each block for the distances array
-    reduction_min<<<num_blocks, 1024, 1024 * sizeof(Dist)>>>(d_jets, d_out, num_threads, n, scheme, one_over_r2);
+    reduction_min<<<num_blocks, 1024, 1024 * sizeof(Dist)>>>(d_jets, d_out, num_threads, n, algo, one_over_r2);
 
     // // Find the minimum of all blocks
     int b = upper_power_of_two(num_blocks - 1) + 1;


### PR DESCRIPTION
Merge the `PseudoJet` and `EtaPhi` structures into a single `PseudoJetExt` structure.
Then use it to sort the input particles according to their grid coordinates and "beam" distance, before inserting them into the grid and running the clustering.
    
Overall this saves 1-2% of the time per event (tested on Dell XPS notebook with a GeForce GTX 960M).